### PR TITLE
Add decoding of function mutability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased changes
 
+## 1.2.0
+
+- Add decoding of function mutability.
+
+## 1.1.0
+
 - Add handling of "Injected Network (by wallet)".
 - Add handling of different blockchain networks (`Ethereum` and `Sepolia`).
 - Add textfield option to enable deriving the function interface from raw `byteCode`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn
 yarn build
 ```
 
-- Run `yarn dev` or `yarn preview` to run the front end locally:
+- Run `yarn dev` to run the front end locally:
 
 ```
 yarn dev
@@ -96,20 +96,20 @@ After connecting the wallet, the number of pairs, and the address of the first p
 
 Without connecting a wallet, you can derive the ABI interface from deployed bytecode for any other EVM network.
 
-The recording shows the loading of a ``Counter`` smart contract interface on Amoy given the deployed bytecode.
+The recording shows the loading of a `Counter` smart contract interface on Amoy given the deployed bytecode.
 After connecting the wallet, the counter value is incremented and read from the contract state.
 
 ![Example_2](./gifs/derivingABIFromBytecode.gif)
 
 ### Example 3 (Proxy-Implementation Pattern)
 
-The recording shows the loading of a proxy-implementation pattern (``Counter`` smart contract) on Sepolia. The counter value is incremented and read from the contract state.
+The recording shows the loading of a proxy-implementation pattern (`Counter` smart contract) on Sepolia. The counter value is incremented and read from the contract state.
 
 ![Example_3](./gifs/proxyImplementation.gif)
 
 ### Example 4 (Writing to chain with `value` and `gasLimit`)
 
-The recording shows how to send ETH when writing to the chain and how to set the ``gasLimit``.
+The recording shows how to send ETH when writing to the chain and how to set the `gasLimit`.
 
 ![Example_4](./gifs/sendETH.gif)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Interact with any contract on-chain (no-ABI/source code needed; the interface is decoded from the bytecode)",
   "author": "Doris Benda",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite preview",

--- a/package.json
+++ b/package.json
@@ -6,19 +6,18 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite preview",
     "build": "tsc && vite build",
     "lint": "eslint .",
     "fmt-check": "prettier --check .",
-    "fmt": "prettier --write .",
-    "preview": "vite preview"
+    "fmt": "prettier --write ."
   },
   "dependencies": {
     "@metamask/etherscan-link": "^3.0.0",
     "@openchainxyz/abi-guesser": "^1.0.2",
     "bootstrap": "^5.3.3",
     "ethers": "^6.11.1",
-    "evmole": "^0.3.3",
+    "evmole": "^0.5.1",
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.1",
     "react-dom": "^18.2.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -121,7 +121,7 @@ const App = () => {
         window.ethereum.removeListener("accountsChanged", handleAccountChanged);
       }
     };
-  }, [selectedNetwork]);
+  }, [provider, selectedNetwork]);
 
   const clearWalletConnection = async () => {
     setAccount(undefined);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,14 @@ const addressRegex = /^0x[0-9a-fA-F]{40}$/;
 // Regular expression pattern to match a hex string
 const hexRegex = /^0x[0-9a-fA-F]*$/;
 
+export interface FunctionInterface {
+  databaseLookUpArray: string[];
+  functionHash: string;
+  inputParameterTypeArray: string[];
+  perfectMatchName: string | undefined;
+  mutability: string;
+}
+
 /**
  * This function validates if a string represents a valid Ethereum address in hex encoding with an "0x" prefix.
  * The length, and the characters are validated.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,10 +1588,10 @@ ethers@^6.11.1:
     tslib "2.4.0"
     ws "8.5.0"
 
-evmole@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/evmole/-/evmole-0.3.3.tgz#7d7f7df728b84127fdaf936952be8f87092f81da"
-  integrity sha512-NHgKqRAvv2aAkRVxtTUvd1ONf+WQvnTfu0kErAXxwyw/3Az4rIyk8JuuBsSvo7I0wMlqVa6yLQ3Rs5mB4E6Adg==
+evmole@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/evmole/-/evmole-0.5.1.tgz#23f26a629d01079ef5f83189dba1374de95af5f8"
+  integrity sha512-6al+Ju+s5Fm5sDYhz3Udlbx88uKQUASlIQlkZeeNQCLzNtUUPyoFkj+SShoHYqUFgA80X8yv/hNK2NVEr7YNOQ==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
# Purpose

Each function interface that is found in the raw bytecode gets its mutability decoded. The following labels are added to the functions:

One of the four labels:

- pure: Pure functions promise not to read from or modify the state.
- view: View functions promise not to modify the state.
- nonPayable: Nonpayable functions promise not to receive Ether. //  This is the solidity default: https://docs.soliditylang.org/en/latest/abi-spec.html#json
-  payable: Payable functions make no promises.

One of the two labels:

- Read (if the function has a `pure` or `view` label as above)
- Write (if the function has a `nonPayable` or `payable` label as above)
       
# Changes     

- Add decoding of function mutability.
- Bump version of `evMole` dependency.
- Change to use vite production mode only:
In development mode, vite serves files via a local dev server without fully bundling them. This can lead to different asset paths or behaviors when loading WebAssembly (Wasm) files, as vite uses on-demand compilation and may not serve wasm files correctly by default. This was a problem since the new `evMole` version has its functionality served via a `wasm` file. 



